### PR TITLE
fix: timezone issues again

### DIFF
--- a/backend/src/assignment/assignment-scheduler.service.ts
+++ b/backend/src/assignment/assignment-scheduler.service.ts
@@ -34,7 +34,7 @@ export class AssignmentSchedulerService {
       }
       acc.get(curr.taskGroupId)?.push({
         ...curr,
-        taskGroupInitialStartDate: new Date(curr.taskGroupInitialStartDate),
+        taskGroupInitialStartDate: curr.taskGroupInitialStartDate,
       });
       return acc;
     }, new Map());
@@ -56,7 +56,8 @@ export class AssignmentSchedulerService {
           userId: nextResponsibleUserId,
           createdAt: isInFirstInterval
             ? taskGroupInitialStartDate
-            : new Date(new Date().setHours(0, 0, 0, 0)),
+            : // IDK if this is correct, what if its 23:00 for example in local time ozne
+              new Date(new Date().setHours(0, 0, 0, 0)),
         }),
       );
       console.info(

--- a/backend/src/db/schema.ts
+++ b/backend/src/db/schema.ts
@@ -85,7 +85,7 @@ export const recurringTaskGroupTable = pgTable('recurring_task_group', {
   description: text('description'),
   interval: interval('interval').notNull(),
   initialStartDate: timestamp('initial_start_date', {
-    mode: 'string',
+    mode: 'date',
   }).notNull(),
   userGroupId: integer('user_group_id').notNull(),
   createdAt: timestamp('created_at').notNull().defaultNow(),

--- a/backend/src/tasks/task-group.controller.ts
+++ b/backend/src/tasks/task-group.controller.ts
@@ -19,7 +19,7 @@ export type CreateTaskGroup = {
   description?: string;
   interval: string;
   userIds: number[];
-  initialStartDate: string;
+  initialStartDate: Date;
   userGroupId: number;
 };
 


### PR DESCRIPTION
We used mode string for the `initialStartDate` column, which returns the date as a string without timezone information, thus javascript didn't handle the date correctly -> changed to mode date which directly returns a date and takes care of mapping